### PR TITLE
Define types for userdata and cache block devices.

### DIFF
--- a/device.te
+++ b/device.te
@@ -67,3 +67,9 @@ type root_block_device, dev_type;
 
 # factory reset protection block device
 type frp_block_device, dev_type;
+
+# Userdata block device mounted on /data.
+type userdata_block_device, dev_type;
+
+# Cache block device mounted on /cache.
+type cache_block_device, dev_type;

--- a/uncrypt.te
+++ b/uncrypt.te
@@ -28,3 +28,7 @@ allow uncrypt powerctl_prop:property_service set;
 allow uncrypt self:capability sys_rawio;
 allow uncrypt block_device:blk_file w_file_perms;
 allow uncrypt block_device:dir r_dir_perms;
+
+# Access userdata block device.
+allow uncrypt userdata_block_device:blk_file rw_file_perms;
+auditallow uncrypt userdata_block_device:blk_file rw_file_perms;

--- a/vold.te
+++ b/vold.te
@@ -93,6 +93,10 @@ binder_call(vold, healthd)
 # talk to keymaster
 allow vold tee_device:chr_file rw_file_perms;
 
+# Access userdata block device.
+allow vold userdata_block_device:blk_file rw_file_perms;
+auditallow vold userdata_block_device:blk_file rw_file_perms;
+
 # For UMS tuning
 allow vold proc_dirty_ratio:file rw_file_perms;
 


### PR DESCRIPTION
Introduce separate types for the userdata and cache block
devices so that we can assign them and allow access to them
in device-specific policy without allowing access to any other
block device (e.g. system).  These types will only be used if
assigned to device node paths in the device-specific file_contexts
configuration.  Otherwise, this change will have no impact - the
userdata and cache block devices will continue to default to block_device
type.

To avoid breakage when these new types are assigned to the userdata
block device, allow access by vold and uncrypt, but auditallow
these accesses to confirm that these are required.

Change-Id: I99d24f06506f51ebf1d186d9c393b3cad60e98d7
Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>